### PR TITLE
Fixed Date format during reset

### DIFF
--- a/AEON HEM v1.groovy
+++ b/AEON HEM v1.groovy
@@ -382,7 +382,7 @@ def reset() {
     state.voltsHigh = 0
     state.voltsLow = 999
     
-    def dateString = new Date().format("m/d/YY", location.timeZone)
+    def dateString = new Date().format("d-MMM-YY", location.timeZone)
     def timeString = new Date().format("h:mm a", location.timeZone)
     sendEvent(name: "energyOne", value: "Since\n"+dateString+"\n"+timeString, unit: "")
     sendEvent(name: "powerOne", value: "", unit: "")    


### PR DESCRIPTION
previous date was "m/dd/YY" which is the Minutes followed by a zero-padded Day and Year.  Minutes was certainly incorrect, but since Dates can be confusing depending the locale when represented as a MM/DD format or DD/MM format, I adjusted to a non-zero-padded day followed by a the 3 character Month abbreviation (e.g. 6-Feb-17).